### PR TITLE
Enhance CMake usage for modern CMake usage and portability.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,47 @@
 cmake_minimum_required(VERSION 3.16)
-project(Noxis)
+project(Noxis C)
 
-set(CMAKE_C_FLAGS "-Wall -Wpedantic -Wextra -Werror")
-set(CMAKE_C_STANDARD 11)
-
-set(CMAKE_BINARY_DIR ${PROJECT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-
-#set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+include(cmake/base.cmake)
+include(cmake/warnings.cmake)
 
 find_package(SDL2 REQUIRED)
 
-set(LINK_LIBS ${SDL2_LIBRARIES})
+add_executable(${PROJECT_NAME})
 
-set(INCLUDE_DIRS ${SDL2_INCLUDE_DIRS} include)
-set(SOURCES
-	"src/utils.c"
-	"src/main.c"
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+        include/utils.h
+        src/utils.c
 
-	"src/core/callbacks.c"
-	"src/core/game.c"
-	"src/core/init.c"
-	"src/core/quit.c"
+        include/core/callbacks.h
+        include/core/game.h
+        include/core/init.h
+        include/core/quit.h
+        src/core/callbacks.c
+        src/core/game.c
+        src/core/init.c
+        src/core/quit.c
+
+        src/main.c
 )
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+target_compile_features(
+    ${PROJECT_NAME}
+    PRIVATE
+        c_std_11
+)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})
+set_default_warnings(${PROJECT_NAME})
+
+target_include_directories(
+    ${PROJECT_NAME}
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+)
+
+target_link_libraries(
+    ${PROJECT_NAME}
+    PRIVATE
+        SDL2::SDL2
+)

--- a/cmake/base.cmake
+++ b/cmake/base.cmake
@@ -1,0 +1,27 @@
+include_guard()
+
+# Generate compile_commands.json for tooling that uses it.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Set output directory layout.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+# Ensure a CMAKE_BUILD_TYPE is set.
+if(NOT CMAKE_BUILD_TYPE)
+    message (STATUS "No build type specified. Defaulting to Debug.")
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type." FORCE)
+endif()
+
+# Create a list of valid CMAKE_BUILD_TYPES for cmake-gui and ccmake.
+set_property(
+    CACHE
+        CMAKE_BUILD_TYPE
+    PROPERTY
+        STRINGS
+            "Debug"
+            "Release"
+            "MinSizeRel"
+            "RelWithDebInfo"
+)

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -1,0 +1,12 @@
+include_guard()
+
+# Define variables for each supported compiler, so that checking is easier
+# later.
+
+if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(USING_CLANG TRUE)
+elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(USING_GCC TRUE)
+elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    set(USING_MSVC TRUE)
+endif()

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,0 +1,83 @@
+include_guard()
+
+option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors." ON)
+
+include(cmake/compilers.cmake)
+
+set(GCC_CLANG_BASE_WARNINGS
+    -Wall
+    -Wextra
+    -Wpedantic
+)
+
+set(MSVC_BASE_WARNINGS
+    /W4
+)
+
+function(set_target_warnings target)
+    # Set warnings for a target
+    #
+    # Args:
+    #     target: The target to set the warnings on.
+    # Keyword args:
+    #     UNKNOWN_MESSAGE: A message to print as a warning if the compiler is unknown.
+    #     MSVC: The list of MSVC warning flags to set.
+    #     CLANG: The list of Clang warning flags to set.
+    #     GCC: The list of GCC warning flags to set.
+
+    cmake_parse_arguments(
+        PARSE_ARGV
+            1
+        WARNINGS
+        ""
+        "TARGET;UNKNOWN_MESSAGE"
+        "MSVC;CLANG;GCC"
+    )
+
+    if(USING_MSVC)
+        set(warnings ${WARNINGS_MSVC})
+    elseif(USING_CLANG)
+        set(warnings ${WARNINGS_CLANG})
+    elseif(USING_GCC)
+        set(warnings ${WARNINGS_GCC})
+    else()
+        # Unknown compiler, warn user.
+        message(WARNING "${UNKNOWN_MESSAGE}")
+    endif()
+
+    target_compile_options(
+        ${target}
+        PRIVATE
+            ${warnings}
+    )
+endfunction()
+
+function(set_default_warnings target)
+    # Set a default warning set to a given target, in a compiler-independent way.
+
+    set_target_warnings(
+        ${target}
+        MSVC
+            ${MSVC_BASE_WARNINGS}
+        CLANG
+            ${GCC_CLANG_BASE_WARNINGS}
+        GCC
+            ${GCC_CLANG_BASE_WARNINGS}
+        UNKNOWN_MESSAGE
+            "Compiler is not known, cannot set warnings."
+    )
+
+    if(WARNINGS_AS_ERRORS)
+        set_target_warnings(
+            ${target}
+            MSVC
+                "/WX"
+            CLANG
+                "-Werror"
+            GCC
+                "-Werror"
+            UNKNOWN_MESSAGE
+                "Compiler is not known, cannot set warnings as errors."
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
Changed CMake usage to modern CMake practices.
- Use SDL2 imported target.
- Avoid portability issues.
- Use `target_` commands with property visibility definitions.
- Add some options for cmake-gui and ccmake and sane defaults.